### PR TITLE
Paths in linked directories need to maintain the path name passed in originally

### DIFF
--- a/rpt.js
+++ b/rpt.js
@@ -23,7 +23,7 @@ function Node (pkg, logical, physical, cache) {
   if (cache[physical]) return cache[physical]
 
   if (!(this instanceof Node)) {
-    return new Node(pkg, physical, physical, cache)
+    return new Node(pkg, logical, physical, cache)
   }
 
   cache[physical] = this

--- a/rpt.js
+++ b/rpt.js
@@ -19,22 +19,23 @@ rpt.Node = Node
 rpt.Link = Link
 
 var ID = 0
-function Node (pkg, path, cache) {
+function Node (pkg, logical, physical, cache) {
   if (cache[path]) return cache[path]
 
   if (!(this instanceof Node)) {
-    return new Node(pkg, path, cache)
+    return new Node(pkg, physical, physical, cache)
   }
 
-  cache[path] = this
+  cache[physical] = this
 
-  debug(this.constructor.name, dpath(path), pkg && pkg._id)
+  debug(this.constructor.name, dpath(physical), pkg && pkg._id)
 
   this.id = ID++
   this.package = pkg
-  this.path = path
-  this.realpath = path
+  this.path = logical
+  this.realpath = physical
   this.parent = null
+  this.isLink = false
   this.children = []
 }
 
@@ -43,23 +44,24 @@ Node.prototype.path = ''
 Node.prototype.realpath = ''
 Node.prototype.children = null
 
-function Link (pkg, path, realpath, cache) {
-  if (cache[path]) return cache[path]
+function Link (pkg, logical, physical, realpath, cache) {
+  if (cache[physical]) return cache[physical]
 
   if (!(this instanceof Link)) {
-    return new Link(pkg, path, realpath)
+    return new Link(pkg, logical, physical, realpath, cache)
   }
 
-  cache[path] = this
+  cache[physical] = this
 
-  debug(this.constructor.name, dpath(path), pkg && pkg._id)
+  debug(this.constructor.name, dpath(physical), pkg && pkg._id)
 
   this.id = ID++
-  this.path = path
+  this.path = logical
   this.realpath = realpath
   this.package = pkg
   this.parent = null
-  this.target = new Node(pkg, realpath, cache)
+  this.target = new Node(pkg, logical, realpath, cache)
+  this.isLink = true
   this.children = this.target.children
 }
 
@@ -69,22 +71,22 @@ Link.prototype = Object.create(Node.prototype, {
 Link.prototype.target = null
 Link.prototype.realpath = ''
 
-function loadNode (p, cache, cb) {
-  debug('loadNode', dpath(p))
-  fs.realpath(p, function (er, real) {
+function loadNode (logical, physical, cache, cb) {
+  debug('loadNode', dpath(logical))
+  fs.realpath(physical, function (er, real) {
     if (er) return cb(er)
-    debug('realpath p=%j real=%j', dpath(p), dpath(real))
+    debug('realpath l=%j p=%j real=%j', dpath(logical), dpath(physical), dpath(real))
     var pj = path.resolve(real, 'package.json')
     rpj(pj, function (er, pkg) {
       pkg = pkg || null
-      var n
-      if (p === real) {
-        n = new Node(pkg, real, cache)
+      var node
+      if (physical === real) {
+        node = new Node(pkg, logical, physical, cache)
       } else {
-        n = new Link(pkg, p, real, cache)
+        node = new Link(pkg, logical, physical, real, cache)
       }
 
-      cb(er, n)
+      cb(er, node)
     })
   })
 }
@@ -106,8 +108,9 @@ function loadChildren (node, cache, cb) {
     if (l === 0) return cb(null, node)
 
     kids.forEach(function (kid) {
-      var p = path.resolve(nm, kid)
-      loadNode(p, cache, then)
+      var kidPath = path.resolve(nm, kid)
+      var kidRealPath = path.resolve(node.realpath,'node_modules',kid)
+      loadNode(kidPath, kidRealPath, cache, then)
     })
 
     function then (er, kid) {
@@ -164,11 +167,11 @@ function loadTree (node, did, cache, cb) {
 }
 
 function rpt (root, cb) {
-  fs.realpath(root, function (er, root) {
+  fs.realpath(root, function (er, realRoot) {
     if (er) return cb(er)
-    debug('rpt', dpath(root))
+    debug('rpt', dpath(realRoot))
     var cache = Object.create(null)
-    loadNode(root, cache, function (er, node) {
+    loadNode(root, realRoot, cache, function (er, node) {
       // if there's an error, it's fine, as long as we got a node
       if (!node) return cb(er)
       loadTree(node, {}, cache, function (lter, tree) {

--- a/rpt.js
+++ b/rpt.js
@@ -20,7 +20,7 @@ rpt.Link = Link
 
 var ID = 0
 function Node (pkg, logical, physical, cache) {
-  if (cache[path]) return cache[path]
+  if (cache[physical]) return cache[physical]
 
   if (!(this instanceof Node)) {
     return new Node(pkg, physical, physical, cache)

--- a/test/basic.js
+++ b/test/basic.js
@@ -4,7 +4,7 @@ var path = require('path')
 var fs = require('fs')
 var archy = require('archy')
 var fixtures = path.resolve(__dirname, 'fixtures')
-var roots = [ 'root', 'other', 'selflink', 'linkedroot', 'deep/root' ]
+var roots = [ 'root', 'other', 'selflink' ]
 var cwd = path.resolve(__dirname, '..')
 
 var symlinks = {
@@ -15,7 +15,9 @@ var symlinks = {
   'linkedroot':
     'root',
   'deep/root':
-    '../root'
+    '../root',
+  'deeproot':
+    'deep'
 }
 
 function cleanup () {
@@ -56,6 +58,34 @@ roots.forEach(function (root) {
       t.equal(actual, expect, root + ' tree')
       t.end()
     })
+  })
+})
+
+test('linkedroot', function (t) {
+  var dir = path.resolve(fixtures, 'linkedroot')
+  var out = dir + '-archy.txt'
+  rpt(dir, function (er, d) {
+    if (er && er.code !== 'ENOENT') throw er
+
+    var actual = archy(archyize(d)).trim()
+    console.log(actual)
+    var expect = fs.readFileSync(out, 'utf8').trim()
+    t.equal(actual, expect, 'linkedroot tree')
+    t.end()
+  })
+})
+
+test('deeproot', function (t) {
+  var dir = path.resolve(fixtures, 'deeproot/root')
+  var out = path.resolve(fixtures, 'deep') + '-archy.txt'
+  rpt(dir, function (er, d) {
+    if (er && er.code !== 'ENOENT') throw er
+
+    var actual = archy(archyize(d)).trim()
+    console.log(actual)
+    var expect = fs.readFileSync(out, 'utf8').trim()
+    t.equal(actual, expect, 'deeproot tree')
+    t.end()
   })
 })
 

--- a/test/fixtures/deep-archy.txt
+++ b/test/fixtures/deep-archy.txt
@@ -1,0 +1,11 @@
+root@1.2.3 test/fixtures/deeproot/root
+├─┬ @scope/x@1.2.3 test/fixtures/deeproot/root/node_modules/@scope/x
+│ └─┬ glob@4.0.5 test/fixtures/deeproot/root/node_modules/@scope/x/node_modules/glob
+│   ├── graceful-fs@3.0.2 test/fixtures/deeproot/root/node_modules/@scope/x/node_modules/glob/node_modules/graceful-fs
+│   ├── inherits@2.0.1 test/fixtures/deeproot/root/node_modules/@scope/x/node_modules/glob/node_modules/inherits
+│   ├─┬ minimatch@1.0.0 test/fixtures/deeproot/root/node_modules/@scope/x/node_modules/glob/node_modules/minimatch
+│   │ ├── lru-cache@2.5.0 test/fixtures/deeproot/root/node_modules/@scope/x/node_modules/glob/node_modules/minimatch/node_modules/lru-cache
+│   │ └── sigmund@1.0.0 test/fixtures/deeproot/root/node_modules/@scope/x/node_modules/glob/node_modules/minimatch/node_modules/sigmund
+│   └── once@1.3.0 test/fixtures/deeproot/root/node_modules/@scope/x/node_modules/glob/node_modules/once
+├── @scope/y@1.2.3 test/fixtures/deeproot/root/node_modules/@scope/y
+└── foo@1.2.3 test/fixtures/deeproot/root/node_modules/foo

--- a/test/fixtures/linkedroot-archy.txt
+++ b/test/fixtures/linkedroot-archy.txt
@@ -1,0 +1,11 @@
+root@1.2.3 test/fixtures/linkedroot
+├─┬ @scope/x@1.2.3 test/fixtures/linkedroot/node_modules/@scope/x
+│ └─┬ glob@4.0.5 test/fixtures/linkedroot/node_modules/@scope/x/node_modules/glob
+│   ├── graceful-fs@3.0.2 test/fixtures/linkedroot/node_modules/@scope/x/node_modules/glob/node_modules/graceful-fs
+│   ├── inherits@2.0.1 test/fixtures/linkedroot/node_modules/@scope/x/node_modules/glob/node_modules/inherits
+│   ├─┬ minimatch@1.0.0 test/fixtures/linkedroot/node_modules/@scope/x/node_modules/glob/node_modules/minimatch
+│   │ ├── lru-cache@2.5.0 test/fixtures/linkedroot/node_modules/@scope/x/node_modules/glob/node_modules/minimatch/node_modules/lru-cache
+│   │ └── sigmund@1.0.0 test/fixtures/linkedroot/node_modules/@scope/x/node_modules/glob/node_modules/minimatch/node_modules/sigmund
+│   └── once@1.3.0 test/fixtures/linkedroot/node_modules/@scope/x/node_modules/glob/node_modules/once
+├── @scope/y@1.2.3 test/fixtures/linkedroot/node_modules/@scope/y
+└── foo@1.2.3 test/fixtures/linkedroot/node_modules/foo

--- a/test/fixtures/other/archy.txt
+++ b/test/fixtures/other/archy.txt
@@ -1,2 +1,2 @@
 test/fixtures/other
-└── glob@4.0.5 test/fixtures/root/node_modules/@scope/x/node_modules/glob (symlink)
+└── glob@4.0.5 test/fixtures/other/node_modules/glob (symlink)

--- a/test/fixtures/selflink/archy.txt
+++ b/test/fixtures/selflink/archy.txt
@@ -1,7 +1,7 @@
 selflink@1.2.3 test/fixtures/selflink
 ├── @scope/y@1.2.3 test/fixtures/selflink/node_modules/@scope/y
 ├─┬ @scope/z@1.2.3 test/fixtures/selflink/node_modules/@scope/z
-│ └── glob@4.0.5 test/fixtures/selflink/node_modules/foo/node_modules/glob (symlink)
+│ └── glob@4.0.5 test/fixtures/selflink/node_modules/@scope/z/node_modules/glob (symlink)
 └─┬ foo@1.2.3 test/fixtures/selflink/node_modules/foo
   ├─┬ glob@4.0.5 test/fixtures/selflink/node_modules/foo/node_modules/glob
   │ ├── graceful-fs@3.0.2 test/fixtures/selflink/node_modules/foo/node_modules/glob/node_modules/graceful-fs
@@ -10,4 +10,4 @@ selflink@1.2.3 test/fixtures/selflink
   │ │ ├── lru-cache@2.5.0 test/fixtures/selflink/node_modules/foo/node_modules/glob/node_modules/minimatch/node_modules/lru-cache
   │ │ └── sigmund@1.0.0 test/fixtures/selflink/node_modules/foo/node_modules/glob/node_modules/minimatch/node_modules/sigmund
   │ └── once@1.3.0 test/fixtures/selflink/node_modules/foo/node_modules/glob/node_modules/once
-  └── selflink@1.2.3 test/fixtures/selflink (symlink)
+  └── selflink@1.2.3 test/fixtures/selflink/node_modules/foo/node_modules/selflink (symlink)

--- a/test/fixtures/selflink/archy.txt
+++ b/test/fixtures/selflink/archy.txt
@@ -1,7 +1,7 @@
 selflink@1.2.3 test/fixtures/selflink
 ├── @scope/y@1.2.3 test/fixtures/selflink/node_modules/@scope/y
 ├─┬ @scope/z@1.2.3 test/fixtures/selflink/node_modules/@scope/z
-│ └── glob@4.0.5 test/fixtures/selflink/node_modules/@scope/z/node_modules/glob (symlink)
+│ └── glob@4.0.5 test/fixtures/selflink/node_modules/foo/node_modules/glob (symlink)
 └─┬ foo@1.2.3 test/fixtures/selflink/node_modules/foo
   ├─┬ glob@4.0.5 test/fixtures/selflink/node_modules/foo/node_modules/glob
   │ ├── graceful-fs@3.0.2 test/fixtures/selflink/node_modules/foo/node_modules/glob/node_modules/graceful-fs
@@ -10,4 +10,4 @@ selflink@1.2.3 test/fixtures/selflink
   │ │ ├── lru-cache@2.5.0 test/fixtures/selflink/node_modules/foo/node_modules/glob/node_modules/minimatch/node_modules/lru-cache
   │ │ └── sigmund@1.0.0 test/fixtures/selflink/node_modules/foo/node_modules/glob/node_modules/minimatch/node_modules/sigmund
   │ └── once@1.3.0 test/fixtures/selflink/node_modules/foo/node_modules/glob/node_modules/once
-  └── selflink@1.2.3 test/fixtures/selflink/node_modules/foo/node_modules/selflink (symlink)
+  └── selflink@1.2.3 test/fixtures/selflink (symlink)


### PR DESCRIPTION
So we track the logical path name– the one that was passed into to start with,
this is what goes in the .path attribute, and the physical path name, which
is the version that starts with the realpath of the starting root. This is
what goes into the realpath attribute of Node objects. Link objects are
unchanged.
