### PR TITLE
Stop intuiting package names

### DIFF
--- a/rpt.js
+++ b/rpt.js
@@ -33,7 +33,6 @@ function Node (pkg, logical, physical, er, cache) {
 
   this.id = ID++
   this.package = pkg || {}
-  if (!this.package.name) this.package.name = path.basename(logical)
   this.path = logical
   this.realpath = physical
   this.parent = null

--- a/test/basic.js
+++ b/test/basic.js
@@ -4,7 +4,7 @@ var path = require('path')
 var fs = require('fs')
 var archy = require('archy')
 var fixtures = path.resolve(__dirname, 'fixtures')
-var roots = [ 'root', 'other', 'selflink' ]
+var roots = [ 'root', 'other', 'selflink', 'noname' ]
 var cwd = path.resolve(__dirname, '..')
 
 var symlinks = {
@@ -132,7 +132,9 @@ function archyize (d, seen) {
     path = d.target.path
   }
 
-  var label = d.package._id ? d.package._id + ' ' : ''
+  var label = d.package._id ? d.package._id + ' ' :
+              d.package.name ? d.package.name + (d.package.version ? '@' + d.package.version : '') + ' ' :
+              ''
   label += path.substr(cwd.length + 1)
 
   if (d . target) {

--- a/test/fixtures/noname/archy.txt
+++ b/test/fixtures/noname/archy.txt
@@ -1,0 +1,2 @@
+test/fixtures/noname
+└── test/fixtures/noname/node_modules/foo


### PR DESCRIPTION
This originally came in as a part of 99cc6a7 as rpt was being
refactored to have fewer fatal conditions and to produce more
normal output. It turns out that it's VERY useful to npm to be
able to distinguish between "no package.json" and "package.json
with only name=dirname".
