### PR TITLE
Make sure Nodes always have `.phantomChildren`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "archy": "^1.0.0",
+    "mkdirp": "^0.5.1",
     "tacks": "^1.2.1",
     "tap": "^6.3.0"
   },

--- a/rpt.js
+++ b/rpt.js
@@ -55,6 +55,7 @@ function Node (pkg, logical, physical, er, cache) {
   this.parent = null
   this.isLink = false
   this.children = []
+  this.phantomChildren = {}
   this.error = er
 }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -3,6 +3,7 @@ var rpt = require('../rpt.js')
 var path = require('path')
 var fs = require('fs')
 var archy = require('archy')
+var mkdirp = require('mkdirp')
 var fixtures = path.resolve(__dirname, 'fixtures')
 var roots = [ 'root', 'other', 'selflink', 'noname' ]
 var cwd = path.resolve(__dirname, '..')
@@ -38,6 +39,7 @@ test('setup symlinks', function (t) {
 
   Object.keys(symlinks).forEach(function (s) {
     var p = path.resolve(cwd, 'test/fixtures', s)
+    mkdirp.sync(path.dirname(p))
     fs.symlinkSync(symlinks [ s ], p, 'dir')
   })
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -138,6 +138,26 @@ test('missing symlinks', function (t) {
   })
 })
 
+test('required properties of Node instances', function(t) {
+  rpt(path.resolve(fixtures, 'root'), function (er, d) {
+    if (er) throw er
+    t.type(d, 'Node')
+    t.type(d.id, 'number')
+    t.type(d.package, 'object')
+    t.equal(d.package.name, 'root')
+    t.equal(d.package.version, '1.2.3')
+    t.type(d.path, 'string')
+    t.type(d.realpath, 'string')
+    t.equal(d.parent, null)
+    t.equal(d.isLink, false)
+    t.type(d.children, 'Array')
+    t.type(d.children[0], 'Node')
+    t.type(d.phantomChildren, 'object')
+    t.equal(d.error, null)
+    t.end()
+  })
+})
+
 
 function archyize (d, seen) {
   seen = seen || {}


### PR DESCRIPTION
Fixes a bug (for me) which occurred when npm was calling
`Object.keys()` on the `.phantomChildren` property of a node even
though there was no such property.

I don’t know why the property was not set in that particular case
and I couldn’t reproduce it once I got things working using this
patch; it doesn’t seem like something that would hurt, though.

([npm-debug.log](https://github.com/npm/read-package-tree/files/409083/npm-debug.log.txt) of the failed install, fwiw.)
