### PR TITLE
Reduce the raceyness of where we get the `path` attribute for Node objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "archy": "^1.0.0",
+    "mkdirp": "^0.5.1",
     "tacks": "^1.2.1",
     "tap": "^6.3.0"
   },

--- a/rpt.js
+++ b/rpt.js
@@ -37,25 +37,27 @@ rpt.Node = Node
 rpt.Link = Link
 
 var ID = 0
-function Node (pkg, logical, physical, er, cache) {
-  if (cache[physical]) return cache[physical]
-
+function Node (pkg, logical, physical, er, cache, fromLink) {
   if (!(this instanceof Node)) {
     return new Node(pkg, logical, physical, er, cache)
   }
 
-  cache[physical] = this
+  var node = cache[physical] || this
+  if (fromLink && cache[physical]) return cache[physical]
 
-  debug(this.constructor.name, dpath(physical), pkg && pkg._id)
+  debug(node.constructor.name, dpath(physical), pkg && pkg._id)
 
-  this.id = ID++
-  this.package = pkg || {}
-  this.path = logical
-  this.realpath = physical
-  this.parent = null
-  this.isLink = false
-  this.children = []
-  this.error = er
+  node.path = logical
+  node.realpath = physical
+  node.error = er
+  if (!cache[physical]) {
+    node.id = ID++
+    node.package = pkg || {}
+    node.parent = null
+    node.isLink = false
+    node.children = []
+  }
+  return cache[physical] = node
 }
 
 Node.prototype.package = null
@@ -80,7 +82,7 @@ function Link (pkg, logical, physical, realpath, er, cache) {
   this.realpath = realpath
   this.package = pkg || {}
   this.parent = null
-  this.target = new Node(this.package, logical, realpath, er, cache)
+  this.target = new Node(this.package, logical, realpath, er, cache, true)
   this.isLink = true
   this.children = this.target.children
   this.error = er

--- a/test/basic.js
+++ b/test/basic.js
@@ -3,6 +3,7 @@ var rpt = require('../rpt.js')
 var path = require('path')
 var fs = require('fs')
 var archy = require('archy')
+var mkdirp = require('mkdirp')
 var fixtures = path.resolve(__dirname, 'fixtures')
 var roots = [ 'root', 'other', 'selflink', 'noname' ]
 var cwd = path.resolve(__dirname, '..')
@@ -38,6 +39,7 @@ test('setup symlinks', function (t) {
 
   Object.keys(symlinks).forEach(function (s) {
     var p = path.resolve(cwd, 'test/fixtures', s)
+    mkdirp.sync(path.dirname(p))
     fs.symlinkSync(symlinks [ s ], p, 'dir')
   })
 


### PR DESCRIPTION
Previously if you had a module AND a symlink to that module in the same
node_modules tree then the value of the `path` attribute would
non-determinstic due to `read-package-tree` doing everything async.

This was causing intermittent failures on node 6.x.
