### PR TITLE
Ignore test fixtures when publishing to NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+test
+.gitignore
+.travis.yml


### PR DESCRIPTION
Hi there!

It looks like `read-package-tree` is published to npm with all its test fixtures.
This prevents `credits-cli` from running on projects that rely on `read-package-tree`.

Thanks for considering this PR!

Best,
Jan